### PR TITLE
Integer indexes

### DIFF
--- a/ProgrammingLanguageNr1/src/5. Run/InterpreterTwo.cs
+++ b/ProgrammingLanguageNr1/src/5. Run/InterpreterTwo.cs
@@ -692,10 +692,10 @@ namespace ProgrammingLanguageNr1
 				var rhsArray = rhs as SortedDictionary<KeyWrapper, object>;
 				var newArray = new SortedDictionary<KeyWrapper, object>();
 				for(int i = 0; i < lhsArray.Count; i++) {
-					newArray.Add(new KeyWrapper(i), lhsArray[new KeyWrapper(i)]);
+					newArray.Add(new KeyWrapper((float)i), lhsArray[new KeyWrapper(i)]);
 				}
 				for(int i = 0; i < rhsArray.Count; i++) {
-					newArray.Add(new KeyWrapper(i + lhsArray.Count), rhsArray[new KeyWrapper(i)]);
+					newArray.Add(new KeyWrapper((float)(i + lhsArray.Count)), rhsArray[new KeyWrapper(i)]);
 				}
 				Console.WriteLine ("Created new array by concatenation: " + ReturnValueConversions.PrettyStringRepresenation(newArray));
 				return newArray;
@@ -894,7 +894,7 @@ namespace ProgrammingLanguageNr1
 			}
 			//for(int i = 0; i < arrayEndSignal.ArraySize; i++) {
 			for(int i = arrayEndSignal.ArraySize - 1; i >= 0; i--) {
-				array.Add(new KeyWrapper(arrayEndSignal.ArraySize - i - 1), values[i]);
+				array.Add(new KeyWrapper((float)(arrayEndSignal.ArraySize - i - 1)), values[i]);
 			}
 			PushValue(array);
 		}

--- a/ProgrammingLanguageNr1/src/5. Run/ReturnValue.cs
+++ b/ProgrammingLanguageNr1/src/5. Run/ReturnValue.cs
@@ -105,7 +105,7 @@ namespace ProgrammingLanguageNr1
 				return ((bool)o) ? "true" : "false";
 			}
 			else if(o.GetType() == typeof(float)) {
-				return o.ToString();	
+				return ((float)o).ToString(CultureInfo.InvariantCulture);
 			}
 			else if(o.GetType() == typeof(int)) {
 				return o.ToString() + "i";
@@ -272,7 +272,7 @@ namespace ProgrammingLanguageNr1
 					return 9999;
 				}
 			} 
-			else if (this.value == typeof(string)) {
+			else if (this.value.GetType() == typeof(string)) {
 				return 10000 + ((string)value).GetHashCode () % 10000;
 			} 
 			else {

--- a/ProgrammingLanguageNr1/src/5. Run/ReturnValue.cs
+++ b/ProgrammingLanguageNr1/src/5. Run/ReturnValue.cs
@@ -230,7 +230,7 @@ namespace ProgrammingLanguageNr1
 					var a = new SortedDictionary<KeyWrapper,object>();
 					string s = (string)obj;
 					for(int i = 0; i < s.Length; i++) {
-						a.Add(new KeyWrapper(i), s);
+						a.Add(new KeyWrapper((float)i), s);
 					}
 					return a;
 				}

--- a/ProgrammingLanguageNr1/src/5. Run/SprakRunner.cs
+++ b/ProgrammingLanguageNr1/src/5. Run/SprakRunner.cs
@@ -429,7 +429,7 @@ namespace ProgrammingLanguageNr1
 			int size = (int)(float)args[0];
 			SortedDictionary<KeyWrapper, object> array = new SortedDictionary<KeyWrapper, object>();
 			for(int i  = 0; i < size; i++) {
-				array.Add(new KeyWrapper(i), VoidType.voidType);
+				array.Add(new KeyWrapper((float)i), VoidType.voidType);
 			}
 			return array;
 		}

--- a/ProgrammingLanguageNr1/src/5. Run/SprakRunner.cs
+++ b/ProgrammingLanguageNr1/src/5. Run/SprakRunner.cs
@@ -381,14 +381,24 @@ namespace ProgrammingLanguageNr1
 			int maxArrayIndex = -1;
 			foreach (var keyWrapper in array.Keys) {
 				var key = keyWrapper.value;
-				if (key.GetType () == typeof(float) &&
+				if (key.GetType () == typeof (float) &&
 				    maxArrayIndex < (float)key) {
 					maxArrayIndex = (int)(float)key;
+				}
+				else if (key.GetType () == typeof (int) &&
+					maxArrayIndex < (int)key) {
+					maxArrayIndex = (int)key;
 				}
 			}
 			//int maxArrayIndex = array.Count; // TODO: this is a bug if the array contains sparse indexes or stuff like that
 
-			array.Add (new KeyWrapper((float)maxArrayIndex + 1), val);
+			KeyWrapper newIndex = new KeyWrapper((float)maxArrayIndex + 1);
+
+			if (array.ContainsKey(newIndex))
+			{
+				throw new Error("Can't append to array");
+			}
+			array.Add (newIndex, val);
 			return VoidType.voidType;
 		}
 

--- a/Sprak_Tests/bin/Debug/code86.txt
+++ b/Sprak_Tests/bin/Debug/code86.txt
@@ -1,0 +1,9 @@
+array a0 = []
+a0[0] = 0
+print(GetIndexes(a0))
+array a1 = [0]
+print(GetIndexes(a1))
+array a2 = [0] + [0]
+print(GetIndexes(a2))
+string a3 = "ab"
+print(GetIndexes(a3))

--- a/Sprak_Tests/tests/DefaultSprakRunner_TEST.cs
+++ b/Sprak_Tests/tests/DefaultSprakRunner_TEST.cs
@@ -2091,6 +2091,59 @@ print(b3)
 			Assert.AreEqual("true", sprakRunner.Output[1]);
 			Assert.AreEqual("false", sprakRunner.Output[2]);
 		}
+
+		[Test()]
+		public void Append()
+		{
+			StringReader programString = new StringReader(
+				@"
+array a1 = []
+Append(a1, 1)
+print(a1 + "" "" + Count(a1))
+
+array a2 = [0]
+Append(a2, 2)
+print(a2+ "" "" + Count(a2))
+
+array a3 = []
+a3[1] = 1
+Append(a3, 3)
+print(a3+ "" "" + Count(a3))
+");
+
+			DefaultSprakRunner sprakRunner = new DefaultSprakRunner(programString);
+			sprakRunner.run(100);
+
+			Assert.AreEqual(0, sprakRunner.getCompileTimeErrorHandler().getErrors().Count);
+			Assert.AreEqual(0, sprakRunner.getRuntimeErrorHandler().getErrors().Count);
+
+			Assert.AreEqual(3, sprakRunner.Output.Count);
+			Assert.AreEqual("[1] 1", sprakRunner.Output[0]);
+			Assert.AreEqual("[0, 2] 2", sprakRunner.Output[1]);
+			Assert.AreEqual("[1, 3] 2", sprakRunner.Output[2]);
+		}
+
+		[Test ()]
+		public void AppendFailure ()
+		{
+			// Test conditions depend on implementation details of array and
+			// Append. If it doesn't work, update or remove the test.
+			StringReader programString = new StringReader (
+				@"
+array a = []
+a[false] = 1
+a[9998] = 2
+Append(a, 3)
+");
+
+			DefaultSprakRunner sprakRunner = new DefaultSprakRunner (programString);
+			sprakRunner.run ();
+
+			Assert.AreEqual (0, sprakRunner.getCompileTimeErrorHandler ().getErrors ().Count);
+			Assert.AreNotEqual (0, sprakRunner.getRuntimeErrorHandler ().getErrors ().Count);
+
+			Assert.AreEqual ("Can't append to array", sprakRunner.getRuntimeErrorHandler ().getErrors () [0].Message);
+		}
 	}
 		
 }

--- a/Sprak_Tests/tests/DefaultSprakRunner_TEST.cs
+++ b/Sprak_Tests/tests/DefaultSprakRunner_TEST.cs
@@ -2144,6 +2144,26 @@ Append(a, 3)
 
 			Assert.AreEqual ("Can't append to array", sprakRunner.getRuntimeErrorHandler ().getErrors () [0].Message);
 		}
+
+		[Test ()]
+		public void IndexType ()
+		{
+			s_output = new List<string> ();
+			TextReader programString = File.OpenText ("code86.txt");
+
+			DefaultSprakRunner program = new DefaultSprakRunner(programString);
+
+			program.run ();
+
+			Assert.AreEqual (0, program.getCompileTimeErrorHandler ().getErrors ().Count);
+			Assert.AreEqual (0, program.getRuntimeErrorHandler ().getErrors ().Count);
+
+			Assert.AreEqual (4, program.Output.Count);
+			Assert.AreEqual ("[0]", program.Output[0]);
+			Assert.AreEqual ("[0]", program.Output [1]);
+			Assert.AreEqual ("[0, 1]", program.Output [2]);
+			Assert.AreEqual ("[0, 1]", program.Output [3]);
+		}
 	}
 		
 }


### PR DESCRIPTION
Array indexes were sometimes integers, sometimes floats causing Append to fail on simple code.

```
array a = [1]
Append(a, 2)
```

More ways of causing problems can be found in tests.

Changes:
- Add float casts when creating array indexes to eleminitate most sources of integers
- Handle integers in Append, just in case some integers remain
- Throw an `Error` from Append in case of index conflict, the old code threw an unhandled exception in such case
